### PR TITLE
chore: Rename Section Title to Bereichsüberschrift

### DIFF
--- a/config/sync/field.field.paragraph.benefits.field_section_title.yml
+++ b/config/sync/field.field.paragraph.benefits.field_section_title.yml
@@ -9,7 +9,7 @@ id: paragraph.benefits.field_section_title
 field_name: field_section_title
 entity_type: paragraph
 bundle: benefits
-label: 'Section Title'
+label: Bereichsüberschrift
 description: ''
 required: false
 translatable: true

--- a/config/sync/field.field.paragraph.blocks.field_section_title.yml
+++ b/config/sync/field.field.paragraph.blocks.field_section_title.yml
@@ -9,7 +9,7 @@ id: paragraph.blocks.field_section_title
 field_name: field_section_title
 entity_type: paragraph
 bundle: blocks
-label: 'Section Title'
+label: Bereichsüberschrift
 description: ''
 required: false
 translatable: true

--- a/config/sync/field.field.paragraph.job_intro.field_section_title.yml
+++ b/config/sync/field.field.paragraph.job_intro.field_section_title.yml
@@ -9,7 +9,7 @@ id: paragraph.job_intro.field_section_title
 field_name: field_section_title
 entity_type: paragraph
 bundle: job_intro
-label: 'Section Title'
+label: Bereichsüberschrift
 description: ''
 required: false
 translatable: true

--- a/config/sync/field.field.paragraph.news_teaser.field_section_title.yml
+++ b/config/sync/field.field.paragraph.news_teaser.field_section_title.yml
@@ -9,7 +9,7 @@ id: paragraph.news_teaser.field_section_title
 field_name: field_section_title
 entity_type: paragraph
 bundle: news_teaser
-label: Abschnittstitel
+label: Bereichsüberschrift
 description: ''
 required: false
 translatable: true

--- a/config/sync/field.field.paragraph.people.field_section_title.yml
+++ b/config/sync/field.field.paragraph.people.field_section_title.yml
@@ -9,7 +9,7 @@ id: paragraph.people.field_section_title
 field_name: field_section_title
 entity_type: paragraph
 bundle: people
-label: 'Section Title'
+label: Bereichsüberschrift
 description: ''
 required: false
 translatable: true

--- a/config/sync/field.field.paragraph.projects_teaser.field_section_title.yml
+++ b/config/sync/field.field.paragraph.projects_teaser.field_section_title.yml
@@ -9,7 +9,7 @@ id: paragraph.projects_teaser.field_section_title
 field_name: field_section_title
 entity_type: paragraph
 bundle: projects_teaser
-label: Abschnittstitel
+label: Bereichsüberschrift
 description: ''
 required: false
 translatable: true

--- a/config/sync/field.field.paragraph.segments_item.field_section_title.yml
+++ b/config/sync/field.field.paragraph.segments_item.field_section_title.yml
@@ -9,7 +9,7 @@ id: paragraph.segments_item.field_section_title
 field_name: field_section_title
 entity_type: paragraph
 bundle: segments_item
-label: 'Section Title'
+label: Bereichsüberschrift
 description: ''
 required: false
 translatable: true


### PR DESCRIPTION
## Summary
- Renames the field label "Section Title" to "Bereichsüberschrift" across all 7 paragraph types
- Machine name `field_section_title` remains unchanged

Closes #23