### PR TITLE
chore: Rename Standort tab Inhalt to Weitere Inhalte

### DIFF
--- a/config/sync/field_group.group_inhalt.node.location.default.yml
+++ b/config/sync/field_group.group_inhalt.node.location.default.yml
@@ -11,7 +11,7 @@ bundle: location
 mode: default
 type: tab
 parent_name: group_tabs
-label: Inhalt
+label: 'Weitere Inhalte'
 description: ''
 weight: 4
 format_type: tab


### PR DESCRIPTION
## Summary
- Renames the "Inhalt" tab on the Location content type form to "Weitere Inhalte"

Closes #39