### PR TITLE
fix: Stage slider not visible (remove absolute from cells)

### DIFF
--- a/web/themes/custom/hpm/templates/paragraph/paragraph--stage-slider-item.html.twig
+++ b/web/themes/custom/hpm/templates/paragraph/paragraph--stage-slider-item.html.twig
@@ -6,7 +6,7 @@
 #}
 {% set caption = content.field_caption|render|striptags|trim %}
 {% set credits = paragraph.field_image.entity.field_credits.value|default(paragraph.field_image_portrait.entity.field_credits.value) %}
-<div class="carousel__item stage-slider__item ml-0 absolute w-full cursor-grab">
+<div class="carousel__item stage-slider__item ml-0 w-full cursor-grab">
   <div class="stage-slider__image-box carousel__image-box h-full top-0 left-0 overflow-hidden relative pt-[133.33%] sm:pt-[92%] md:pt-[40%]">
     {% if content.field_image_portrait[0] %}
       {% set portrait_img = content.field_image_portrait[0]['#media'] ?? content.field_image_portrait[0]['#item'] %}

--- a/web/themes/custom/hpm/templates/paragraph/paragraph--stage-slider.html.twig
+++ b/web/themes/custom/hpm/templates/paragraph/paragraph--stage-slider.html.twig
@@ -18,7 +18,7 @@
             {% set portrait_media = slide.field_image_portrait.entity %}
             {% set caption_text = slide.field_caption.value %}
             {% set is_first = loop.first %}
-            <div class="carousel__item stage-slider__item ml-0 absolute w-full cursor-grab">
+            <div class="carousel__item stage-slider__item ml-0 w-full cursor-grab">
               <div class="stage-slider__image-box carousel__image-box h-full top-0 left-0 overflow-hidden relative pt-[133.33%] sm:pt-[92%] md:pt-[40%]">
                 <picture class="absolute inset-0 block h-full w-full">
                   {% if wide_media %}


### PR DESCRIPTION
## Summary
- Remove `absolute` class from stage slider carousel items in both templates
- Flickity requires cells in normal document flow to measure and position them — the `absolute` class prevented Flickity from initializing

## Test plan
- [ ] Verify stage slider is visible and functional on homepage
- [ ] Verify slider autoplay with progress dots works
- [ ] Verify drag/swipe navigation works