### PR TITLE
fix: Pathauto selection_logic plugin to and

### DIFF
--- a/config/sync/pathauto.pattern.job_listing.yml
+++ b/config/sync/pathauto.pattern.job_listing.yml
@@ -16,6 +16,6 @@ selection_criteria:
       node: node
     bundles:
       job_listing: job_listing
-selection_logic: plugin
+selection_logic: and
 weight: 0
 relationships: {  }

--- a/config/sync/pathauto.pattern.landing_page.yml
+++ b/config/sync/pathauto.pattern.landing_page.yml
@@ -16,6 +16,6 @@ selection_criteria:
       node: node
     bundles:
       landing_page: landing_page
-selection_logic: plugin
+selection_logic: and
 weight: 0
 relationships: {  }

--- a/config/sync/pathauto.pattern.location.yml
+++ b/config/sync/pathauto.pattern.location.yml
@@ -16,6 +16,6 @@ selection_criteria:
       node: node
     bundles:
       location: location
-selection_logic: plugin
+selection_logic: and
 weight: 0
 relationships: {  }

--- a/config/sync/pathauto.pattern.page.yml
+++ b/config/sync/pathauto.pattern.page.yml
@@ -16,6 +16,6 @@ selection_criteria:
       node: node
     bundles:
       page: page
-selection_logic: plugin
+selection_logic: and
 weight: 0
 relationships: {  }

--- a/config/sync/pathauto.pattern.project.yml
+++ b/config/sync/pathauto.pattern.project.yml
@@ -16,6 +16,6 @@ selection_criteria:
       node: node
     bundles:
       project: project
-selection_logic: plugin
+selection_logic: and
 weight: 0
 relationships: {  }


### PR DESCRIPTION
## Summary
- All pathauto patterns had `selection_logic: plugin` which caused bundle conditions to not be enforced — location nodes were matching the `job_listing` pattern instead of `location`, generating `stellenangebote/...` URLs instead of `standorte/...`
- Changed all 5 patterns to `selection_logic: and` so bundle conditions are properly enforced

Fixes #9

## Test plan
- [ ] `drush cim -y && drush cr`
- [ ] Save a Standort node → URL should be `standorte/[city]`
- [ ] Save a Stellenangebot → URL should be `stellenangebote/[title]`
- [ ] Save a Projekt → URL should be `projekte/[title]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)