### PR TITLE
fix: Use drupal_url() for language-aware internal links

### DIFF
--- a/web/themes/custom/hpm/templates/layout/page.html.twig
+++ b/web/themes/custom/hpm/templates/layout/page.html.twig
@@ -41,7 +41,7 @@
   </button>
 
   {# Contact Button #}
-  <a class="button button--small header__contact z-2" href="{{ url('internal:/kontakt') }}" title="{{ 'Kontakt aufnehmen'|t }}">
+  <a class="button button--small header__contact z-2" href="{{ drupal_url('internal:/kontakt') }}" title="{{ 'Kontakt aufnehmen'|t }}">
     <span class="button-text">{{ 'Kontakt'|t }}</span>
   </a>
 </header>
@@ -63,7 +63,7 @@
 
       <nav class="navigation-additional relative flex flex-col items-start gap-3" aria-label="{{ 'Weitere Links'|t }}">
         <a class="text-link font-case text-[0.9375rem] leading-[1.2]"
-           href="{{ url('internal:/projekte') }}"
+           href="{{ drupal_url('internal:/projekte') }}"
            title="{{ 'Projekte'|t }}">
           <span class="text-link__text copy">{{ 'Projekte'|t }}</span>
           <span class="link-icon -mt-[1px]">
@@ -71,7 +71,7 @@
           </span>
         </a>
         <a class="text-link font-case text-[0.9375rem] leading-[1.2]"
-           href="{{ url('internal:/neuigkeiten') }}"
+           href="{{ drupal_url('internal:/neuigkeiten') }}"
            title="{{ 'Neuigkeiten'|t }}">
           <span class="text-link__text copy">{{ 'Neuigkeiten'|t }}</span>
           <span class="link-icon -mt-[1px]">

--- a/web/themes/custom/hpm/templates/node/node--location.html.twig
+++ b/web/themes/custom/hpm/templates/node/node--location.html.twig
@@ -28,7 +28,7 @@
                   sm:col-span-10 sm:col-start-2 sm:mt-3
                   md:col-span-12 md:col-start-1">
         <a class="text-link text-link--back font-case text-[0.9375rem] leading-[1.2] text-hpm-darkred"
-           href="{{ url('internal:/standorte') }}"
+           href="{{ drupal_url('internal:/standorte') }}"
            title="Zur Standortübersicht">
           <span class="text-link__text copy">Zur Übersicht</span>
           <span class="link-icon link-icon--back -mt-[1px]">

--- a/web/themes/custom/hpm/templates/node/node--news--teaser.html.twig
+++ b/web/themes/custom/hpm/templates/node/node--news--teaser.html.twig
@@ -29,7 +29,7 @@
   </h3>
   <div class="mt-5 lg:mt-6">
     <a class="text-link text-hpm-darkred copy"
-       href="{{ url('internal:/neuigkeiten') }}#news-{{ node.id() }}"
+       href="{{ drupal_url('internal:/neuigkeiten') }}#news-{{ node.id() }}"
        title="Artikel lesen">
       <span class="text-link__text copy">Artikel lesen</span>
       <span class="link-icon">

--- a/web/themes/custom/hpm/templates/node/node--project.html.twig
+++ b/web/themes/custom/hpm/templates/node/node--project.html.twig
@@ -28,7 +28,7 @@
                   sm:col-span-10 sm:col-start-2 sm:mt-3
                   md:col-span-12 md:col-start-1">
         <a class="text-link text-link--back font-case text-[0.9375rem] leading-[1.2] text-hpm-darkred"
-           href="{{ url('internal:/projekte') }}"
+           href="{{ drupal_url('internal:/projekte') }}"
            title="Zur Projektübersicht">
           <span class="text-link__text copy">Alle Projekte</span>
           <span class="link-icon link-icon--back -mt-[1px]">

--- a/web/themes/custom/hpm/templates/paragraph/paragraph--job-intro.html.twig
+++ b/web/themes/custom/hpm/templates/paragraph/paragraph--job-intro.html.twig
@@ -25,7 +25,7 @@
                 sm:col-span-10 sm:col-start-2
                 lg:col-span-2 lg:col-start-auto">
       <a class="text-link font-case text-[0.9375rem] leading-[1.2] text-hpm-darkred text-link--back"
-         href="{{ url('internal:/stellenangebote') }}"
+         href="{{ drupal_url('internal:/stellenangebote') }}"
          title="Zu den Stellenangeboten">
         <span class="text-link__text copy">Zur Übersicht</span>
         <span class="link-icon link-icon--back -mt-[1px]">


### PR DESCRIPTION
## Summary
- Previous PR #76 used `url('internal:/...')` which only accepts route names and caused 500 errors
- Changed to `drupal_url('internal:/...')` from twig_tweak module, which properly handles `internal:` URI scheme and language prefixes

## Test plan
- [ ] No more 500 errors on Standort, Stellenangebot, Projekt pages
- [ ] All internal links correctly include `/de/` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)