### PR TITLE
fix: Simplify WYSIWYG editor for editors (#85)

### DIFF
--- a/config/sync/editor.editor.basic_html.yml
+++ b/config/sync/editor.editor.basic_html.yml
@@ -14,51 +14,26 @@ settings:
   toolbar:
     items:
       - bold
-      - italic
       - '|'
       - link
       - '|'
       - bulletedList
-      - numberedList
-      - '|'
-      - blockQuote
-      - drupalInsertImage
       - '|'
       - heading
-      - code
-      - '|'
-      - sourceEditing
   plugins:
     ckeditor5_heading:
       enabled_headings:
         - heading2
         - heading3
         - heading4
-        - heading5
-        - heading6
-    ckeditor5_imageResize:
-      allow_resize: true
     ckeditor5_list:
       properties:
         reversed: false
-        startIndex: true
-        styles: true
+        startIndex: false
+        styles: false
       multiBlock: true
-    ckeditor5_sourceEditing:
-      allowed_tags:
-        - '<cite>'
-        - '<dl>'
-        - '<dt>'
-        - '<dd>'
-        - '<a hreflang>'
-        - '<blockquote cite>'
-        - '<h2 id>'
-        - '<h3 id>'
-        - '<h4 id>'
-        - '<h5 id>'
-        - '<h6 id>'
 image_upload:
-  status: true
+  status: false
   scheme: public
   directory: inline-images
   max_size: null

--- a/config/sync/filter.format.basic_html.yml
+++ b/config/sync/filter.format.basic_html.yml
@@ -1,51 +1,19 @@
 uuid: 10594efc-30f8-43b4-8baf-4010c8c3f5f7
 langcode: de
 status: true
-dependencies:
-  module:
-    - editor
+dependencies: {  }
 _core:
   default_config_hash: mclCbTlJwWJORez4Y1eX2MqA0aGjSMAoJb3TaBABcK8
 name: 'Einfaches HTML'
 format: basic_html
 weight: 0
 filters:
-  editor_file_reference:
-    id: editor_file_reference
-    provider: editor
-    status: true
-    weight: 11
-    settings: {  }
-  filter_align:
-    id: filter_align
-    provider: filter
-    status: true
-    weight: 7
-    settings: {  }
-  filter_caption:
-    id: filter_caption
-    provider: filter
-    status: true
-    weight: 8
-    settings: {  }
   filter_html:
     id: filter_html
     provider: filter
     status: true
     weight: -10
     settings:
-      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol start type> <strong> <em> <code> <li> <img src alt data-entity-uuid data-entity-type height width data-caption data-align>'
+      allowed_html: '<br> <p> <h2> <h3> <h4> <a href hreflang> <ul> <li> <strong>'
       filter_html_help: false
       filter_html_nofollow: false
-  filter_html_image_secure:
-    id: filter_html_image_secure
-    provider: filter
-    status: true
-    weight: 9
-    settings: {  }
-  filter_image_lazy_load:
-    id: filter_image_lazy_load
-    provider: filter
-    status: true
-    weight: 15
-    settings: {  }


### PR DESCRIPTION
## Summary
- Reduce basic_html CKEditor toolbar to: **Bold**, **Link**, **Bulleted List**, **Heading** (h2, h3, h4)
- Remove: italic, numbered list, blockquote, image insert, code, source editing
- Disable image upload
- Restrict allowed HTML tags to: `<br> <p> <h2> <h3> <h4> <a> <ul> <li> <strong>`

## Test plan
- [ ] Edit a content node using basic_html format — only Bold, Link, List, Heading visible
- [ ] Heading dropdown shows only h2, h3, h4 (no h5/h6)
- [ ] No image upload button in toolbar